### PR TITLE
Rethrow exceptions instead of throwing them again to keep their stack trace

### DIFF
--- a/UnityProject/Assets/Plugins/AsyncAwaitUtil/Source/IEnumeratorAwaitExtensions.cs
+++ b/UnityProject/Assets/Plugins/AsyncAwaitUtil/Source/IEnumeratorAwaitExtensions.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 using UnityEngine;
@@ -154,7 +155,7 @@ public static class IEnumeratorAwaitExtensions
 
             if (_exception != null)
             {
-                throw _exception;
+                ExceptionDispatchInfo.Capture(_exception).Throw();
             }
 
             return _result;
@@ -202,7 +203,7 @@ public static class IEnumeratorAwaitExtensions
 
             if (_exception != null)
             {
-                throw _exception;
+                ExceptionDispatchInfo.Capture(_exception).Throw();
             }
         }
 

--- a/UnityProject/Assets/Plugins/AsyncAwaitUtil/Source/TaskExtensions.cs
+++ b/UnityProject/Assets/Plugins/AsyncAwaitUtil/Source/TaskExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using UnityEngine;
 
@@ -17,7 +18,7 @@ public static class TaskExtensions
 
         if (task.IsFaulted)
         {
-            throw task.Exception;
+            ExceptionDispatchInfo.Capture(task.Exception).Throw();
         }
     }
 
@@ -31,7 +32,7 @@ public static class TaskExtensions
 
         if (task.IsFaulted)
         {
-            throw task.Exception;
+            ExceptionDispatchInfo.Capture(task.Exception).Throw();
         }
 
         yield return task.Result;

--- a/UnityProject/Assets/Plugins/UniRx/Scripts/Notification.cs
+++ b/UnityProject/Assets/Plugins/UniRx/Scripts/Notification.cs
@@ -8,6 +8,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
 using System;
 
 #pragma warning disable 0659
@@ -270,7 +271,8 @@ namespace UniRx
             /// <summary>
             /// Throws the exception.
             /// </summary>
-            public override T Value { get { throw exception; } }
+			// Note: the 2nd "throw" is never reached:
+            public override T Value { get { ExceptionDispatchInfo.Capture(exception).Throw(); throw null; } }
 
             /// <summary>
             /// Returns the exception.

--- a/UnityProject/Assets/Plugins/UniRx/Scripts/Observer.cs
+++ b/UnityProject/Assets/Plugins/UniRx/Scripts/Observer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 
 namespace UniRx
@@ -492,7 +493,7 @@ namespace UniRx
     internal static class Stubs
     {
         public static readonly Action Nop = () => { };
-        public static readonly Action<Exception> Throw = ex => { throw ex; };
+        public static readonly Action<Exception> Throw = ex => { ExceptionDispatchInfo.Capture(ex).Throw(); };
 
         // marker for CatchIgnore and Catch avoid iOS AOT problem.
         public static IObservable<TSource> CatchIgnore<TSource>(Exception ex)
@@ -505,19 +506,19 @@ namespace UniRx
     {
         public static readonly Action<T> Ignore = (T t) => { };
         public static readonly Func<T, T> Identity = (T t) => t;
-        public static readonly Action<Exception, T> Throw = (ex, _) => { throw ex; };
+        public static readonly Action<Exception, T> Throw = (ex, _) => { ExceptionDispatchInfo.Capture(ex).Throw(); };
     }
 
     internal static class Stubs<T1, T2>
     {
         public static readonly Action<T1, T2> Ignore = (x, y) => { };
-        public static readonly Action<Exception, T1, T2> Throw = (ex, _, __) => { throw ex; };
+        public static readonly Action<Exception, T1, T2> Throw = (ex, _, __) => { ExceptionDispatchInfo.Capture(ex).Throw(); };
     }
 
 
     internal static class Stubs<T1, T2, T3>
     {
         public static readonly Action<T1, T2, T3> Ignore = (x, y, z) => { };
-        public static readonly Action<Exception, T1, T2, T3> Throw = (ex, _, __, ___) => { throw ex; };
+        public static readonly Action<Exception, T1, T2, T3> Throw = (ex, _, __, ___) => { ExceptionDispatchInfo.Capture(ex).Throw(); };
     }
 }

--- a/UnityProject/Assets/Plugins/UniRx/Scripts/Operators/Wait.cs
+++ b/UnityProject/Assets/Plugins/UniRx/Scripts/Operators/Wait.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.ExceptionServices;
 
 namespace UniRx.Operators
 {
@@ -36,7 +37,7 @@ namespace UniRx.Operators
                 }
             }
 
-            if (ex != null) throw ex;
+            if (ex != null) ExceptionDispatchInfo.Capture(ex).Throw();
             if (!seenValue) throw new InvalidOperationException("No Elements.");
 
             return value;

--- a/UnityProject/Assets/Plugins/UniRx/Scripts/Subjects/AsyncSubject.cs
+++ b/UnityProject/Assets/Plugins/UniRx/Scripts/Subjects/AsyncSubject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
 using UniRx.InternalUtil;
 
 #if (ENABLE_MONO_BLEEDING_EDGE_EDITOR || ENABLE_MONO_BLEEDING_EDGE_STANDALONE)
@@ -29,7 +30,7 @@ namespace UniRx
             {
                 ThrowIfDisposed();
                 if (!isStopped) throw new InvalidOperationException("AsyncSubject is not completed yet");
-                if (lastError != null) throw lastError;
+                if (lastError != null) ExceptionDispatchInfo.Capture(lastError).Throw();
                 return lastValue;
             }
         }
@@ -315,7 +316,7 @@ namespace UniRx
 
             if (lastError != null)
             {
-                throw lastError;
+                ExceptionDispatchInfo.Capture(lastError).Throw();
             }
 
             if (!hasValue)

--- a/UnityProject/Assets/Plugins/UniRx/Scripts/Subjects/BehaviorSubject.cs
+++ b/UnityProject/Assets/Plugins/UniRx/Scripts/Subjects/BehaviorSubject.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.ExceptionServices;
 using UniRx.InternalUtil;
 
 namespace UniRx
@@ -23,7 +24,7 @@ namespace UniRx
             get
             {
                 ThrowIfDisposed();
-                if (lastError != null) throw lastError;
+                if (lastError != null) ExceptionDispatchInfo.Capture(lastError).Throw();
                 return lastValue;
             }
         }

--- a/UnityProject/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
+++ b/UnityProject/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
 using System.Reflection;
 using System.Threading;
 using UniRx.InternalUtil;
@@ -444,7 +445,7 @@ namespace UniRx
                     // Throw exception when calling from a worker thread.
                     var ex = new Exception("UniRx requires a MainThreadDispatcher component created on the main thread. Make sure it is added to the scene before calling UniRx from a worker thread.");
                     UnityEngine.Debug.LogException(ex);
-                    throw ex;
+                    ExceptionDispatchInfo.Capture(ex).Throw();
                 }
 
                 if (isQuitting)

--- a/UnityProject/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Observable.Unity.cs
+++ b/UnityProject/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Observable.Unity.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
 using UniRx.Triggers;
 using UnityEngine;
 using System.Threading;
@@ -156,7 +157,7 @@ namespace UniRx
             {
                 if (reThrowOnError && HasError)
                 {
-                    throw Error;
+                    ExceptionDispatchInfo.Capture(Error).Throw();
                 }
 
                 return false;
@@ -1147,7 +1148,7 @@ namespace UniRx
         internal static class Stubs
         {
             public static readonly Action Nop = () => { };
-            public static readonly Action<Exception> Throw = ex => { throw ex; };
+            public static readonly Action<Exception> Throw = ex => { ExceptionDispatchInfo.Capture(ex).Throw(); };
 
             // Stubs<T>.Ignore can't avoid iOS AOT problem.
             public static void Ignore<T>(T t)


### PR DESCRIPTION
When an exception is thrown again ("throw ex"), its stack will be
overwritten. Instead, it should be rethrown with its original context.

More info here (Figure 2):
https://msdn.microsoft.com/en-us/magazine/mt620018.aspx

Issue #5