### PR TITLE
Add support for awaiting IAsyncOperation<T> from UnityEngine.Resource…

### DIFF
--- a/UnityProject/Assets/Plugins/AsyncAwaitUtil/Source/IEnumeratorAwaitExtensions.cs
+++ b/UnityProject/Assets/Plugins/AsyncAwaitUtil/Source/IEnumeratorAwaitExtensions.cs
@@ -55,6 +55,23 @@ public static class IEnumeratorAwaitExtensions
         return GetAwaiterReturnSelf(instruction);
     }
 
+    public static TaskAwaiter<TResult> GetAwaiter<TResult>(this IAsyncOperation<TResult> op)
+    {
+        var tcs = new TaskCompletionSource<TResult>();
+        op.Completed += r =>
+        {
+            if (r.OperationException != null)
+            {
+                tcs.SetException(r.OperationException);
+            }
+            else
+            {
+                tcs.SetResult(r.Result);
+            }
+        };
+        return tcs.Task.GetAwaiter();
+    }
+
     public static SimpleCoroutineAwaiter<UnityEngine.Object> GetAwaiter(this ResourceRequest instruction)
     {
         var awaiter = new SimpleCoroutineAwaiter<UnityEngine.Object>();


### PR DESCRIPTION
The new AddressableAssets plugin currently returns IAsyncOperation<T> for many operations which can dynamically load assets.  Currently they don't have formal async/await support though it is on the roadmap.  This PR adds GetAwaiter support for IAsyncOperation<T>.